### PR TITLE
Solve the positional offset between the mouse click and the bomb object.

### DIFF
--- a/GameRenderer.cs
+++ b/GameRenderer.cs
@@ -31,7 +31,7 @@ namespace TheAdventure
         private static GameRenderer? _singleton;
         private DateTimeOffset _lastFrameRenderedAt = DateTimeOffset.MinValue;
 
-        public GameRenderer(Sdl sdl, GameWindow gameWindow, GameLogic gameLogic)
+        public GameRenderer(Sdl sdl, GameWindow gameWindow, GameLogic gameLogic, GameCamera gameCamera)
         {
             _window = gameWindow;
             _gameLogic = gameLogic;
@@ -39,9 +39,9 @@ namespace TheAdventure
             _renderer = (Renderer*)gameWindow.CreateRenderer();
             _textures = new Dictionary<int, IntPtr>();
             _textureData = new Dictionary<int, TextureData>();
-            _camera = new GameCamera();
+            _camera = gameCamera;
             _camera.Width = 800;
-            _camera.Height = 600;
+            _camera.Height = 800;
 
             // TODO: Check if _singleton is not null, if it is, clear resources.
 

--- a/GameWindow.cs
+++ b/GameWindow.cs
@@ -46,5 +46,7 @@ namespace TheAdventure
         public void Destroy(){
             _sdl.DestroyWindow((Window*)_window);
         }
+        
+        public IntPtr Window => _window;
     }
 }

--- a/InputLogic.cs
+++ b/InputLogic.cs
@@ -7,13 +7,17 @@ namespace TheAdventure{
         private GameLogic _gameLogic;
         private GameWindow _gameWindow;
         private GameRenderer _renderer;
+        private GameCamera _camera;
+        private IntPtr _window;
         private DateTimeOffset _lastUpdate;
 
-        public InputLogic(Sdl sdl, GameWindow window, GameRenderer renderer, GameLogic logic){
+        public InputLogic(Sdl sdl, GameWindow window, GameRenderer renderer, GameLogic logic, GameCamera camera){
             _sdl = sdl;
             _gameLogic = logic;
             _gameWindow = window;
             _renderer = renderer;
+            _camera = camera;
+            _window = window.Window;
             _lastUpdate = DateTimeOffset.UtcNow;
         }
 
@@ -25,6 +29,9 @@ namespace TheAdventure{
             Event ev = new Event();
             var mouseX = 0;
             var mouseY = 0;
+            var relativeMouseX = 0;
+            var relativeMouseY = 0;
+            int windowWidth, windowHeight;
             while (_sdl.PollEvent(ref ev) != 0)
             {
                 if (ev.Type == (uint)EventType.Quit)
@@ -163,8 +170,12 @@ namespace TheAdventure{
 
             _lastUpdate = currentTime;
 
-            if (mouseButtonStates[(byte)MouseButton.Primary] == 1){
-                _gameLogic.AddBomb(mouseX, mouseY);
+            if (mouseButtonStates[(byte)MouseButton.Primary] == 1)
+            {
+                _sdl.GetWindowSize((Window*)_window, &windowWidth, &windowHeight);
+                relativeMouseX = mouseX - windowWidth / 2 + _camera.X;
+                relativeMouseY = mouseY - windowHeight / 2 + _camera.Y;
+                _gameLogic.AddBomb(relativeMouseX, relativeMouseY);
             }
             return false;
         }

--- a/Program.cs
+++ b/Program.cs
@@ -21,8 +21,9 @@ public static class Program
 
         var gameWindow = new GameWindow(sdl);
         var gameLogic = new GameLogic();
-        var gameRenderer = new GameRenderer(sdl, gameWindow, gameLogic);
-        var inputLogic = new InputLogic(sdl, gameWindow, gameRenderer, gameLogic);
+        var gameCamera = new GameCamera();
+        var gameRenderer = new GameRenderer(sdl, gameWindow, gameLogic, gameCamera);
+        var inputLogic = new InputLogic(sdl, gameWindow, gameRenderer, gameLogic, gameCamera);
 
         gameLogic.LoadGameState();
 


### PR DESCRIPTION
### Issue:
Upon clicking the window, an **offset** occurs between the click point and the bomb's animation rendering location.

### Proposed Solution:
Address the offset by accounting for the texture rendering originating from the **center** of the window, considering both **right** and **bottom** directions, along with the **camera's X and Y positions**.

### Result:
Following implementation, the bomb now accurately renders at the mouse's position upon clicking.