### PR TITLE
Fps counter and performance improvements

### DIFF
--- a/Assets/bomb.json
+++ b/Assets/bomb.json
@@ -9,7 +9,7 @@
     },
     "fileName" : "BombExploding.png",
     "animations" : {
-        "Explode" : {
+        "BOMB_EXPLODE" : {
             "startFrame" : {
                 "row" : 0,
                 "col" : 0

--- a/Assets/player.json
+++ b/Assets/player.json
@@ -8,71 +8,71 @@
         "offsetY" : 42
     },
     "fileName" : "player.png",
-    "animations" : {
-        "IdleDown" : {
-            "startFrame" : {
-                "row" : 0,
-                "col" : 0
-            },
-            "endFrame" : {
-                "row" : 0,
-                "col" : 5
-            },
-            "durationMs" : 1000,
-            "loop" : true
-        },
-        "MoveLeft": {
-            "startFrame" : {
-                "row" : 4,
-                "col" : 0
-            },
-            "endFrame" : {
-                "row" : 4,
-                "col" : 5
-            },
-            "durationMs" : 1000,
-            "loop" : true,
-            "flip" : 1
-        },
-        "MoveRight": {
-            "startFrame" : {
-                "row" : 4,
-                "col" : 0
-            },
-            "endFrame" : {
-                "row" : 4,
-                "col" : 5
-            },
-            "durationMs" : 1000,
-            "loop" : true,
-            "flip" : 0
-        },
-        "MoveDown": {
-            "startFrame" : {
-                "row" : 3,
-                "col" : 0
-            },
-            "endFrame" : {
-                "row" : 3,
-                "col" : 5
-            },
-            "durationMs" : 1000,
-            "loop" : true,
-            "flip" : 0
-        },
-        "MoveUp": {
-            "startFrame" : {
-                "row" : 5,
-                "col" : 0
-            },
-            "endFrame" : {
-                "row" : 5,
-                "col" : 5
-            },
-            "durationMs" : 1000,
-            "loop" : true,
-            "flip" : 0
-        }
+  "animations": {
+    "PLAYER_IDLE_DOWN": {
+      "startFrame": {
+        "row": 0,
+        "col": 0
+      },
+      "endFrame": {
+        "row": 0,
+        "col": 5
+      },
+      "durationMs": 1000,
+      "loop": true
+    },
+    "PLAYER_MOVE_LEFT": {
+      "startFrame": {
+        "row": 4,
+        "col": 0
+      },
+      "endFrame": {
+        "row": 4,
+        "col": 5
+      },
+      "durationMs": 1000,
+      "loop": true,
+      "flip": 1
+    },
+    "PLAYER_MOVE_RIGHT": {
+      "startFrame": {
+        "row": 4,
+        "col": 0
+      },
+      "endFrame": {
+        "row": 4,
+        "col": 5
+      },
+      "durationMs": 1000,
+      "loop": true,
+      "flip": 0
+    },
+    "PLAYER_MOVE_DOWN": {
+      "startFrame": {
+        "row": 3,
+        "col": 0
+      },
+      "endFrame": {
+        "row": 3,
+        "col": 5
+      },
+      "durationMs": 1000,
+      "loop": true,
+      "flip": 0
+    },
+    "PLAYER_MOVE_UP": {
+      "startFrame": {
+        "row": 5,
+        "col": 0
+      },
+      "endFrame": {
+        "row": 5,
+        "col": 5
+      },
+      "durationMs": 1000,
+      "loop": true,
+      "flip": 0
     }
+  }
     
 }

--- a/GameWindow.cs
+++ b/GameWindow.cs
@@ -52,7 +52,8 @@ public unsafe class GameWindow : IDisposable
             throw new Exception("Failed to create renderer.");
         }
 
-        _sdl.RenderSetVSync((Renderer*)renderer, 1);
+        if(Globals.RUN_PERF_TEST == false)
+            _sdl.RenderSetVSync((Renderer*)renderer, 1);
 
         return renderer;
     }

--- a/Globals.cs
+++ b/Globals.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TheAdventure
+{
+    public static class Globals
+    {
+        public static bool RUN_PERF_TEST = true;
+    }
+}

--- a/Models/AnimationId.cs
+++ b/Models/AnimationId.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TheAdventure.Models
+{
+    public enum AnimationId
+    {
+        NONE,
+
+        BOMB_EXPLODE,
+
+        PLAYER_IDLE_DOWN,
+        PLAYER_MOVE_UP,
+        PLAYER_MOVE_DOWN,
+        PLAYER_MOVE_LEFT,
+        PLAYER_MOVE_RIGHT
+    }
+}

--- a/Models/Data/Tile.cs
+++ b/Models/Data/Tile.cs
@@ -1,3 +1,5 @@
+using TheAdventure.Models;
+
 public class Tile
 {
     public int Id { get; set; }
@@ -5,5 +7,5 @@ public class Tile
     public int ImageWidth { get; set; }
     public int ImageHeight { get; set; }
 
-    public int InternalTextureId { get; set; } = -1;
+    public TextureData InternalTexture { get; set; }
 }

--- a/Models/PlayerObject.cs
+++ b/Models/PlayerObject.cs
@@ -5,9 +5,9 @@ namespace TheAdventure.Models;
 
 public class PlayerObject : RenderableGameObject
 {
-    private int _pixelsPerSecond = 192;
+    public int PixelsPerSecond { get; } = 192;
 
-    private string _currentAnimation = "IdleDown";
+    private AnimationId _currentAnimation = AnimationId.PLAYER_IDLE_DOWN;
 
 
     public PlayerObject(SpriteSheet spriteSheet, int x, int y) : base(spriteSheet, (x, y))
@@ -24,11 +24,12 @@ public class PlayerObject : RenderableGameObject
             down <= double.Epsilon &&
             left <= double.Epsilon &&
             right <= double.Epsilon &&
-            _currentAnimation == "IdleDown"){
+            _currentAnimation == AnimationId.PLAYER_IDLE_DOWN)
+        {
             return;
         }
 
-        var pixelsToMove = time * _pixelsPerSecond;
+        var pixelsToMove = time * PixelsPerSecond;
 
         var x = Position.X + (int)(right * pixelsToMove);
         x -= (int)(left * pixelsToMove);
@@ -56,30 +57,19 @@ public class PlayerObject : RenderableGameObject
             y = height - 6;
         }
 
-        if (y < Position.Y && _currentAnimation != "MoveUp"){
-            _currentAnimation = "MoveUp";
-            //Console.WriteLine($"Attempt to switch to {_currentAnimation}");
-        }
-        if (y > Position.Y && _currentAnimation != "MoveDown"){
-            _currentAnimation = "MoveDown";
-            //Console.WriteLine($"Attempt to switch to {_currentAnimation}");
-        }
-        if (x > Position.X && _currentAnimation != "MoveRight"){
-            _currentAnimation = "MoveRight";
-            //Console.WriteLine($"Attempt to switch to {_currentAnimation}");
-        }
-        if (x < Position.X && _currentAnimation != "MoveLeft"){
-            _currentAnimation = "MoveLeft";
-            //Console.WriteLine($"Attempt to switch to {_currentAnimation}");
-        }
-        if (x == Position.X && _currentAnimation != "IdleDown" &&
-            y == Position.Y && _currentAnimation != "IdleDown"){
-            _currentAnimation = "IdleDown";
-            //Console.WriteLine($"Attempt to switch to {_currentAnimation}");
+        AnimationId newAnimation =
+            y < Position.Y ? AnimationId.PLAYER_MOVE_UP :
+            y > Position.Y ? AnimationId.PLAYER_MOVE_DOWN :
+            x > Position.X ? AnimationId.PLAYER_MOVE_RIGHT :
+            x < Position.X ? AnimationId.PLAYER_MOVE_LEFT :
+            AnimationId.PLAYER_IDLE_DOWN;
+
+        if (newAnimation != _currentAnimation)
+        {
+            //Console.WriteLine($"Will to switch to {_currentAnimation}");
+            SpriteSheet.ActivateAnimation(_currentAnimation);
         }
 
-        //Console.WriteLine($"Will to switch to {_currentAnimation}");
-        SpriteSheet.ActivateAnimation(_currentAnimation);
         Position = (x, y);
     }
 }

--- a/Models/SpriteSheet.cs
+++ b/Models/SpriteSheet.cs
@@ -26,9 +26,9 @@ public class SpriteSheet
     public string? FileName { get; set; }
 
     public Animation? ActiveAnimation { get; private set; }
-    public Dictionary<string, Animation> Animations { get; init; } = new();
+    public Dictionary<AnimationId, Animation> Animations { get; init; } = new();
 
-    private int _textureId = -1;
+    private TextureData _texture;
     private DateTimeOffset _animationStart = DateTimeOffset.MinValue;
 
     public SpriteSheet(){
@@ -49,8 +49,8 @@ public class SpriteSheet
         if(!string.IsNullOrWhiteSpace(parentFolder) && !string.IsNullOrWhiteSpace(FileName)){
             filePath = Path.Combine(parentFolder, FileName);
         }
-        if(_textureId == -1 && !string.IsNullOrWhiteSpace(filePath)){
-            _textureId = renderer.LoadTexture(filePath, out _);
+        if(_texture == null && !string.IsNullOrWhiteSpace(filePath)){
+            _texture = renderer.LoadTexture(filePath, out _);
         }
     }
 
@@ -67,9 +67,9 @@ public class SpriteSheet
         LoadTexture(renderer);
     }
 
-    public void ActivateAnimation(string name)
+    public void ActivateAnimation(AnimationId animationId)
     {
-        if (!Animations.TryGetValue(name, out var animation)) return;
+        if (!Animations.TryGetValue(animationId, out var animation)) return;
 
         ActiveAnimation = animation;
         _animationStart = DateTimeOffset.Now;
@@ -79,7 +79,7 @@ public class SpriteSheet
     {
         if (ActiveAnimation == null)
         {
-            renderer.RenderTexture(_textureId, new Rectangle<int>(0, 0, FrameWidth, FrameHeight),
+            renderer.RenderTexture(_texture, new Rectangle<int>(0, 0, FrameWidth, FrameHeight),
                 new Rectangle<int>(dest.X - FrameCenter.OffsetX, dest.Y - FrameCenter.OffsetY, FrameWidth, FrameHeight),
                 RendererFlip.None, angle, rotationCenter);
         }
@@ -105,10 +105,15 @@ public class SpriteSheet
             var currentRow = ActiveAnimation.StartFrame.Row + currentFrame / ColumnCount;
             var currentCol = ActiveAnimation.StartFrame.Col + currentFrame % ColumnCount;
 
-            renderer.RenderTexture(_textureId,
+            renderer.RenderTexture(_texture,
                 new Rectangle<int>(currentCol * FrameWidth, currentRow * FrameHeight, FrameWidth, FrameHeight),
                 new Rectangle<int>(dest.X - FrameCenter.OffsetX, dest.Y - FrameCenter.OffsetY, FrameWidth, FrameHeight),
                 ActiveAnimation.Flip, angle, rotationCenter);
         }
+    }
+
+    public object Clone()
+    {
+        return MemberwiseClone();
     }
 }

--- a/Models/TextureData.cs
+++ b/Models/TextureData.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TheAdventure.Models
+{
+    public class TextureData
+    {
+        public nint Texture { get; }
+        public TextureInfo Info { get; }
+
+        public TextureData(nint texture, TextureInfo info)
+        {
+            Texture = texture;
+            Info = info;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Silk.NET.SDL;
+using System.Diagnostics;
 
 namespace TheAdventure;
 
@@ -23,15 +24,30 @@ public static class Program
             var engine = new Engine(renderer, input);
 
             engine.InitializeWorld();
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+            long tickCount = 0;
 
             bool quit = false;
             while (!quit)
             {
+
                 quit = input.ProcessInput();
                 if (quit) break;
                 
                 engine.ProcessFrame();
                 engine.RenderFrame();
+
+                ++tickCount;
+
+                if (Globals.RUN_PERF_TEST && stopwatch.Elapsed.TotalSeconds > 2)
+                {
+                    stopwatch.Stop();
+                    Console.WriteLine((float)Math.Round(tickCount / stopwatch.Elapsed.TotalSeconds, 2) + " FPS (avg.)");
+                    tickCount = 0;
+                    stopwatch.Reset();
+                    stopwatch.Start();
+                }
             }
         }
 

--- a/TheAdventure.csproj
+++ b/TheAdventure.csproj
@@ -16,40 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="Assets\BombExploding.png" />
-      <Content Include="Assets\BombExploding.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\grass.tsj" />
-      <Content Include="Assets\grass.tsj">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\grass_001.png" />
-      <Content Include="Assets\grass_001.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\grass_002.png" />
-      <Content Include="Assets\grass_002.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\grass_003.png" />
-      <Content Include="Assets\grass_003.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\grass_004.png" />
-      <Content Include="Assets\grass_004.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\player.png" />
-      <Content Include="Assets\player.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\terrain.png" />
-      <Content Include="Assets\terrain.png">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="Assets\terrain.tmj" />
-      <Content Include="Assets\terrain.tmj">
+      <None Remove="Assets\**" />
+      <Content Include="Assets\**">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>


### PR DESCRIPTION
* added a console FPS logger and a perf. test mode with disabled v-sync
* fixed player not being able to move if time delta between frames is too small
* changed animation tags from string to enum
* avoided hash table look-up on texture renderings
* avoided full texture reloading on bomb creation
* ensured all assets get automatically copied to build output dir

=> ~10% FPS improvement on local debug build

~ Filip Andrei-Dan, IE