### PR TITLE
[PR 2] Bomb cooldown + game exit on ESC and death + bomb spawned in faced direction

### DIFF
--- a/Engine.cs
+++ b/Engine.cs
@@ -73,7 +73,7 @@ namespace TheAdventure
                 _currentLevel.Height * _currentLevel.TileHeight));
         }
 
-        public void ProcessFrame()
+        public bool ProcessFrame()
         {
             var currentTime = DateTimeOffset.Now;
             var secsSinceLastFrame = (currentTime - _lastUpdate).TotalSeconds;
@@ -108,11 +108,10 @@ namespace TheAdventure
             var itemsToRemove = new List<int>();
             itemsToRemove.AddRange(GetAllTemporaryGameObjects().Where(gameObject => gameObject.IsExpired)
                 .Select(gameObject => gameObject.Id).ToList());
-
-            if (addBomb)
-            {
+            
+            // should not be able to add bombs if the player is dead, since the game is basically over
+            if (addBomb && _player.State.State != PlayerObject.PlayerState.GameOver)
                 AddBomb(_player.Position.X, _player.Position.Y, false);
-            }
 
             foreach (var gameObjectId in itemsToRemove)
             {
@@ -127,6 +126,8 @@ namespace TheAdventure
                 }
                 _gameObjects.Remove(gameObjectId);
             }
+
+            return _player.isGameOver();
         }
 
         public void RenderFrame()

--- a/Engine.cs
+++ b/Engine.cs
@@ -109,9 +109,20 @@ namespace TheAdventure
             itemsToRemove.AddRange(GetAllTemporaryGameObjects().Where(gameObject => gameObject.IsExpired)
                 .Select(gameObject => gameObject.Id).ToList());
             
+            var bombX = _player.Position.X;
+            var bombY = _player.Position.Y - 4;
+            // values in px - sprite width is 12 px, but we want to add some space between the bomb spawn point and player
+            if (_player.State.Direction == PlayerObject.PlayerStateDirection.Up)
+                bombY -= 16; // (0, 0) is top left
+            else if (_player.State.Direction == PlayerObject.PlayerStateDirection.Down)
+                bombY += 16;
+            if (_player.State.Direction == PlayerObject.PlayerStateDirection.Left)
+                bombX -= 16;
+            else if (_player.State.Direction == PlayerObject.PlayerStateDirection.Right)
+                bombX += 16;
             // should not be able to add bombs if the player is dead, since the game is basically over
             if (addBomb && _player.State.State != PlayerObject.PlayerState.GameOver)
-                AddBomb(_player.Position.X, _player.Position.Y, false);
+                AddBomb(bombX, bombY, false);
 
             foreach (var gameObjectId in itemsToRemove)
             {

--- a/Engine.cs
+++ b/Engine.cs
@@ -19,6 +19,8 @@ namespace TheAdventure
         private DateTimeOffset _lastUpdate = DateTimeOffset.Now;
         private DateTimeOffset _lastPlayerUpdate = DateTimeOffset.Now;
 
+        TemporaryGameObject? bomb = null;
+
         public Engine(GameRenderer renderer, Input input)
         {
             _renderer = renderer;
@@ -216,13 +218,19 @@ namespace TheAdventure
 
         private void AddBomb(int x, int y, bool translateCoordinates = true)
         {
-
+            if (bomb != null)
+            {
+                if (bomb.IsExpired)
+                    bomb = null;
+                else
+                    return;
+            }
             var translated = translateCoordinates ? _renderer.TranslateFromScreenToWorldCoordinates(x, y) : new Vector2D<int>(x, y);
             
             var spriteSheet = SpriteSheet.LoadSpriteSheet("bomb.json", "Assets", _renderer);
             if(spriteSheet != null){
                 spriteSheet.ActivateAnimation("Explode");
-                TemporaryGameObject bomb = new(spriteSheet, 2.1, (translated.X, translated.Y));
+                bomb = new(spriteSheet, 2.1, (translated.X, translated.Y));
                 _gameObjects.Add(bomb.Id, bomb);
             }
         }

--- a/Input.cs
+++ b/Input.cs
@@ -52,9 +52,17 @@ namespace TheAdventure
             ReadOnlySpan<byte> _keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
             return _keyboardState[(int)KeyCode.Down] == 1;
         }
+
+        public bool IsEscPressed()
+        {
+            ReadOnlySpan<byte> _keyboardState = new(_sdl.GetKeyboardState(null), (int)KeyCode.Count);
+            return _keyboardState[(int)KeyCode.Escape] == 1;
+        }
         
         public bool ProcessInput()
         {
+            if (IsEscPressed())
+                return true;
             var currentTime = DateTimeOffset.UtcNow;
             Event ev = new Event();
             var mouseX = 0;

--- a/Models/PlayerObject.cs
+++ b/Models/PlayerObject.cs
@@ -22,6 +22,7 @@ public class PlayerObject : RenderableGameObject
     }
 
     private int _pixelsPerSecond = 192;
+    private DateTimeOffset _gameOverStart;
 
 
     public (PlayerState State, PlayerStateDirection Direction) State{ get; private set; }
@@ -52,6 +53,14 @@ public class PlayerObject : RenderableGameObject
 
     public void GameOver(){
         SetState(PlayerState.GameOver, PlayerStateDirection.None);
+        _gameOverStart = DateTimeOffset.Now;
+    }
+
+    public bool isGameOver(){
+        // is 1.75 seconds so the animation has time to play, and the player can process what happened
+        if (State.State == PlayerState.GameOver && (DateTimeOffset.Now - _gameOverStart).TotalMilliseconds >= 1750)
+            return true;
+        return false;
     }
 
     public void Attack(bool up, bool down, bool left, bool right)

--- a/Program.cs
+++ b/Program.cs
@@ -30,7 +30,7 @@ public static class Program
                 quit = input.ProcessInput();
                 if (quit) break;
                 
-                engine.ProcessFrame();
+                quit = engine.ProcessFrame();
                 engine.RenderFrame();
             }
         }


### PR DESCRIPTION
Made it so only one player created bomb can exist at a time.
Game quit on pressing Esc button.
Game quit after 1.75s of death.
Bomb now spawns in the direction the player is facing, properly aligned on the Y axis, with some space between the player position and the bomb spawn position.